### PR TITLE
chore: Add .clinerules

### DIFF
--- a/.clinerules/general.md
+++ b/.clinerules/general.md
@@ -1,0 +1,35 @@
+# General Rules
+
+## Directory Structure
+
+```
+.
+├── src/
+│   ├── main.c                # C entrypoint for running mruby bytecode
+│   └── main.rb               # mruby script embedding logic for the tool
+└── test
+    └── mi_test.rb            # test
+```
+
+## src/main.rb
+
+### Important Notes
+
+- You can write `mruby`, not MRI `ruby`. Be aware that there are many classes and methods that exist in MRI but not in mruby.
+  - For example, `require` cannot be used.
+- Only the following libraries and classes are available because they are imported from external libraries.
+  - ENV
+  - JSON
+  - MTest
+  - Tempfile
+
+### Implementation Policy
+
+- Implement as a unit as much as possible as a singleton method within `module Mi`.
+  - For testability, do not call exit within singleton methods.
+  - For testability, do not call ARGV within singleton methods.
+
+## Testing (test/mi_test.rb)
+
+- Tests are performed using MTest by loading (evaluating) src/main.rb
+- Tests the singleton methods of the `Mi` module.


### PR DESCRIPTION
-   Adds a new file `.clinerules/general.md` to define the directory structure, the available libraries, and implementation policies for the mruby scripts.
-   Specifies the use of mruby instead of MRI ruby and lists the available libraries.
-   Outlines testing procedures using MTest.