### PR TITLE
chore: Update build and CI configurations for Ubuntu 24.04 and macOS-arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   smoke:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     steps:
       - name: Checkout code
@@ -24,7 +24,7 @@ jobs:
   unit:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-24.04-arm, macos-14]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     steps:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,7 +13,7 @@ jobs:
       # write permission is required for autolabeler
       # otherwise, read permission is required at least
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04-arm, macos-14]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
@@ -24,10 +24,10 @@ jobs:
 
       - name: Rename binary
         run: |
-          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-            mv mi mi-linux
+          if [[ "${{ matrix.os }}" == "ubuntu-24.04-arm" ]]; then
+            mv mi mi-linux-arm64
           else
-            mv mi mi-macos
+            mv mi mi-macos-arm64
           fi
 
       - name: Upload to GitHub Release

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   rubocop:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The `mi` tool takes a task name as input, loads the corresponding task definitio
 ### ✅ Recommended: Download Prebuilt Binary
 
 1. Go to the [Releases page](https://github.com/hoshinotsuyoshi/mi/releases)
-2. Download the binary for your OS (e.g., `mi-macos`, `mi-linux`)
+2. Download the binary for your OS (e.g., `mi-macos-arm64`, `mi-linux-arm64`)
 3. Make it executable:
 
    ```sh


### PR DESCRIPTION

Update the build and CI configurations to use Ubuntu 24.04-arm and macOS-14 runners. It also renames the binaries to include the arm64 architecture.