### PR TITLE
feat: Support model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,158 +1,164 @@
 # mi
 
-This is a command-line tool (`mi`) that leverages the Gemini API to generate content based on user-defined tasks. It executes Ruby logic via mruby, embedded within a statically compiled binary. Tasks are dynamically loaded from user-defined scripts. These scripts are located in the user's configuration directory, allowing for highly customizable behavior without requiring external Ruby dependencies.
+`mi` is a command-line interface tool designed to interact with the Gemini API for generating content based on user-defined tasks. It executes custom Ruby logic via mruby, which is embedded directly within a statically compiled binary. This approach allows tasks to be dynamically loaded from user configuration scripts, providing flexibility without requiring an external Ruby installation.
 
 ## Overview
 
-The `mi` tool takes a task name as input, loads the corresponding task definition from a Ruby script, interacts with the Gemini API based on the task's specifications, and outputs the results. The core logic is written in Ruby and executed using mruby, ensuring a small footprint and fast execution.
+The `mi` tool functions by taking a specified task name, locating and loading the corresponding Ruby script from the user's configuration directory. This script defines the prompt and schema for the initial interaction with the Gemini API. `mi` sends the user input (or lack thereof) through the task's defined prompt, retrieves a draft answer from the API, and then performs a second API call to evaluate the draft answer for factual correctness and relevance. The final output is a structured JSON object containing the evaluated answer and scores.
 
 ## Key Features
 
-*   **Task-Based Content Generation:** Generates content based on user-defined tasks.
-*   **Dynamic Task Loading:** Tasks are loaded dynamically from Ruby scripts located in the user's configuration directory (`$XDG_CONFIG_HOME/mi/tasks/<task_name>/main.rb`).
-*   **mruby Execution:** Executes Ruby code via mruby, embedded in a statically compiled binary.
-*   **Gemini API Interaction:** Interacts with the Gemini API to generate content based on custom schemas and prompts defined in the tasks.
-*   **Two-Phase Evaluation:** Evaluates initial Gemini API responses for factual correctness and relevance before final output.
-*   **Customizable Schemas:** Supports customization through Ruby scripts to define schemas and tailor the API interaction.
+*   **Task-Based Generation:** Generates content based on modular, user-defined tasks.
+*   **Dynamic Task Loading:** Automatically discovers and loads task definitions from Ruby scripts located in `$XDG_CONFIG_HOME/mi/tasks/`.
+*   **Embedded mruby Execution:** Runs task logic written in Ruby using an embedded mruby interpreter, resulting in a self-contained, statically compiled binary.
+*   **Gemini API Integration:** Interacts with the Google Gemini API using task-defined prompts and schemas.
+*   **Two-Phase Evaluation:** Implements a built-in second API call to evaluate the initial generated content for confidence and fit score.
+*   **Customizable Prompts & Schemas:** Tasks define the specific text prompt and expected response schema for the first API call.
+*   **Task Listing:** Includes a command to list all available tasks discovered in the configuration directory.
 
 ## Installation / Usage
 
 ### ✅ Recommended: Download Prebuilt Binary
 
-1. Go to the [Releases page](https://github.com/hoshinotsuyoshi/mi/releases)
-2. Download the binary for your OS (e.g., `mi-macos-arm64`, `mi-linux-arm64`)
-3. Make it executable:
+1.  Visit the [Releases page](https://github.com/hoshinotsuyoshi/mi/releases).
+2.  Download the appropriate binary for your operating system and architecture.
+3.  Make the binary executable:
 
-   ```sh
-   chmod +x ./mi
-   ```
+    ```sh
+    chmod +x ./mi
+    ```
 
-4. (Optional) Move it to your `PATH`:
+4.  (Optional) Move the binary to a directory included in your system's `PATH`, such as `/usr/local/bin/`:
 
-   ```sh
-   mv ./mi /usr/local/bin/
-   ```
+    ```sh
+    mv ./mi /usr/local/bin/
+    ```
 
 ### 🛠️ Alternative: Build from Source
 
-1. Clone the repository:
+1.  Ensure you have a C compiler (like `clang`) and GNU `make` installed.
+2.  Clone the repository:
 
-   ```sh
-   git clone https://github.com/hoshinotsuyoshi/mi.git
-   cd mi
-   ```
+    ```sh
+    git clone https://github.com/hoshinotsuyoshi/mi.git
+    cd mi
+    ```
 
-2. Build the binary:
+3.  Build the binary:
 
-   ```sh
-   make
-   ```
+    ```sh
+    make
+    ```
 
-   This compiles:
-
-   * `mruby` with the default configuration
-   * The task execution logic into `mruby` bytecode
-   * A statically linked mi binary that embeds the `mruby` bytecode
+    This process compiles mruby, the core Ruby logic into bytecode, and links everything into a single `mi` executable.
 
 ### 🔧 Setup & Run
 
-1. Set your Gemini API key:
+1.  Obtain a Gemini API key and set it as the `GEMINI_API_KEY` environment variable:
 
-   ```sh
-   export GEMINI_API_KEY="YOUR_GEMINI_API_KEY"
-   ```
+    ```sh
+    export GEMINI_API_KEY="YOUR_GEMINI_API_KEY"
+    ```
 
-2. Run a task:
+2.  List available tasks:
 
-   ```sh
-   mi run <task_name>
-   ```
+    ```sh
+    mi list
+    ```
 
-   * `<task_name>` must match a directory under `$XDG_CONFIG_HOME/mi/tasks/`, such as `my_task/main.rb`
-   * Input can be piped in via stdin unless using `--no-stdin`
+    This command searches `$XDG_CONFIG_HOME/mi/tasks/` for task definitions (directories containing `main.rb`). Tasks in subdirectories (e.g., `category/task_name`) are listed with their full path.
 
-3. (Optional) Provide task input via stdin:
+3.  Run a task:
 
-   Input should be a valid JSON object. It will be passed to the task's `text` method.
+    ```sh
+    mi run <task_name>
+    ```
 
-4. Output:
+    *   `<task_name>` corresponds to the name of a directory (or path within subdirectories) under `$XDG_CONFIG_HOME/mi/tasks/` that contains a `main.rb` script.
+    *   By default, the tool reads input from stdin. Use the `--no-stdin` flag if the task does not require external input.
+    *   If stdin is provided as a JSON object containing `confidence` and `fit_score` keys, the tool will exit with an error if either value is less than 0.8. Otherwise, the raw input is passed to the task's `text` method.
 
-   Output is a JSON object containing the result, confidence score, and fit score:
+4.  Output:
 
-   ```json
-   {
-     "main": "Generated content",
-     "confidence": 0.95,
-     "fit_score": 0.90
-   }
-   ```
+    The tool outputs a JSON object to stdout representing the evaluated result from the Gemini API:
+
+    ```json
+    {
+      "main": "The generated and evaluated content.",
+      "confidence": 0.95,  // Self-assessed factual correctness (0-1)
+      "fit_score": 0.90     // Relevance and completeness w.r.t. question (0-1)
+    }
+    ```
 
 ## Task Customization
 
-Tasks are defined by Ruby scripts located in `$XDG_CONFIG_HOME/mi/tasks/<task_name>/main.rb`. Each task script should define a class that includes:
+Tasks are defined by Ruby scripts located in `$XDG_CONFIG_HOME/mi/tasks/<task_name>/main.rb`. Each `main.rb` file must define a class that provides the core logic for interacting with the Gemini API.
 
-*   A `text` method: This method takes the input (if any) and returns a prompt string for the Gemini API. This prompt is used in the first API call to generate the draft answer.
-*   A `response_schema` method: This method returns a JSON schema that describes the expected format of the Gemini API's response. This schema is used to validate the Gemini API's first response, and to construct the evaluation prompt in the second API call.
+The class within the script must implement the following methods:
 
-### Example Task Definition
+*   `text(input)`: This method receives the input read from stdin (if any) as a string. It should return the final text prompt string that will be sent to the Gemini API in the first call.
+*   `response_schema`: This method must return a JSON schema object defining the expected structure of the response from the *first* Gemini API call.
+*   `(Optional) model`: This method can return a string specifying the desired Gemini model to use for this task, overriding the default (`gemini-2.0-flash-lite`). The model must be one of the internally supported options.
+
+### Example Task Definition (`$XDG_CONFIG_HOME/mi/tasks/summarize_article/main.rb`)
 
 ```ruby
-# $XDG_CONFIG_HOME/mi/tasks/cookie_recipe/main.rb
+Class.new(Mi) do
+  # Defines the prompt sent to the Gemini API.
+  # 'input' contains the text read from stdin.
+  def text(input)
+    "Summarize the following article concisely:
 
-Class.new do
-  def text(_input)
-    "List a few popular cookie recipes, and include the amounts of ingredients."
+#{input}"
   end
 
+  # Defines the expected structure of the API response.
+  # Used for schema validation in the first call and building the evaluation prompt.
   def response_schema
     {
-      "type": "ARRAY",
-      "items": {
-        "type": "OBJECT",
-        "properties": {
-          "recipeName": {
-            "type": "STRING"
-          },
-          "ingredients": {
-            "type": "ARRAY",
-            "items": {
-              "type": "STRING"
-            }
-          }
-        },
-        "propertyOrdering": [
-          "recipeName",
-          "ingredients"
-        ]
-      }
+      "type": "STRING"
     }
   end
+
+  # (Optional) Specify a different model for this task.
+  # def model
+  #   "gemini-2.0-flash"
+  # end
 end
 ```
 
 ## Requirements / Dependencies
 
-*   `clang` or another C compiler
-*   `curl` for making HTTP requests
-*   GNU `make` for building
-*   A Unix-like environment (macOS, Linux, etc.)
-*   A Gemini API key (set as the `GEMINI_API_KEY` environment variable)
+*   A Unix-like operating system (macOS, Linux, etc.)
+*   A C compiler (like `clang`)
+*   GNU `make`
+*   `curl` command-line tool
+*   A valid Gemini API key (set as the `GEMINI_API_KEY` environment variable)
 
 ## Directory Structure
 
 ```
-.
-├── Makefile                  # Build script for compiling the CLI tool
+.                          (mi source repository)
+├── Makefile               # Build script
 ├── src/
-│   ├── main.c                # C entrypoint for running embedded Ruby bytecode
-│   └── main.rb               # Ruby script embedding logic for the tool
-└── LICENSE                   # Project license (MIT)
+│   ├── main.c             # C entrypoint (embeds mruby and bytecode)
+│   └── main.rb            # Core Ruby logic for mi commands
+└── LICENSE                # MIT License
 ```
 
-Task definitions are stored in:
+User-defined tasks are located in the XDG config directory:
 
 ```
-$XDG_CONFIG_HOME/mi/tasks/<task_name>/main.rb
+$XDG_CONFIG_HOME/
+└── mi/
+    └── tasks/
+        ├── <task_name_1>/
+        │   └── main.rb      # Task definition 1
+        ├── <task_name_2>/
+        │   └── main.rb      # Task definition 2
+        └── <category>/
+            └── <task_name_3>/
+                └── main.rb  # Nested task definition 3
 ```
 
 ## Roadmap

--- a/examples/tasks/summarize_pr/summarize_pr/main.rb
+++ b/examples/tasks/summarize_pr/summarize_pr/main.rb
@@ -1,6 +1,6 @@
 # Summarize a Git diff into an English PR description
 
-Class.new do
+Class.new(Mi) do
   def text(input)
     <<~PROMPT
       You are a senior software engineer.
@@ -14,7 +14,11 @@ Class.new do
     PROMPT
   end
 
-  def response_schema
-    { type: "STRING" }
-  end
+  # def response_schema
+  #   { type: "STRING" }
+  # end
+
+  # def model
+  #   "gemini-2.0-flash-lite"
+  # end
 end

--- a/examples/tasks/summarize_pr/translate_to_ja/main.rb
+++ b/examples/tasks/summarize_pr/translate_to_ja/main.rb
@@ -1,6 +1,6 @@
 # Translate an English PR description into natural Japanese
 
-Class.new do
+Class.new(Mi) do
   def text(input)
     $stderr.puts input # debug
 
@@ -17,7 +17,11 @@ Class.new do
     PROMPT
   end
 
-  def response_schema
-    { type: "STRING" }
-  end
+  # def response_schema
+  #   { type: "STRING" }
+  # end
+
+  # def model
+  #   "gemini-2.0-flash-lite"
+  # end
 end

--- a/examples/tasks/update_readme/update_readme/main.rb
+++ b/examples/tasks/update_readme/update_readme/main.rb
@@ -1,6 +1,6 @@
 # update readme
 
-Class.new do
+Class.new(Mi) do
   def text(_input)
     # NOTE: This works only on my local machine :)
     main   = File.read('/Users/hoshino/ghq/github.com/hoshinotsuyoshi/mi/src/main.rb')
@@ -38,7 +38,7 @@ Class.new do
     string.sub('<<<src/main.rb>>>', main).sub('<<<README.md>>>', readme)
   end
 
-  def response_schema
-    { type: "STRING" }
+  def model
+    "gemini-2.5-flash-preview-04-17"
   end
 end


### PR DESCRIPTION
Migrate tasks to inherit from the new `Mi` class instead of using `Class.new do ... end`. This change involves transforming `Mi` from a module into a class.

The `Mi` class now provides default implementations for `text`, `response_schema`, and `model` methods, which task classes can override. The `Mi.run` method is updated to accept and utilize the model specified by the task class.

This refactoring allows tasks to define their preferred model and simplifies the task definition by providing default behavior for common methods.